### PR TITLE
[Fix]: In order to know if a transaction was successful or not, the resp...

### DIFF
--- a/payment.php
+++ b/payment.php
@@ -35,7 +35,11 @@ if (isset($_POST['paymillToken'])) {
         $privateApiKey
     );
 
-    if (isset($transaction['response_code']) && ($transaction['response_code'] == 20000)) {
+    $isStatusClosed = isset($transaction['status']) && $transaction['status'] == 'closed';
+
+    $isResponseCodeSuccess = isset($transaction['response_code']) && $transaction['response_code'] == 20000;
+
+    if ($isStatusClosed && $isResponseCodeSuccess) {
         echo '<strong>Transaction successful!</strong>';
     } else {
         echo '<strong>Transaction not successful!</strong> <br />';


### PR DESCRIPTION
...onse code should be checked against 20000 and not the status code.
